### PR TITLE
Frontend: responsive titels

### DIFF
--- a/web/src/layouts/MainLayout.vue
+++ b/web/src/layouts/MainLayout.vue
@@ -1,8 +1,12 @@
 <script lang="ts" setup>
 import { ref } from 'vue';
+import { useRoute } from 'vue-router';
 
 // reactive state to show the drawer or not
 const drawer = ref(true)
+
+// get the route object, needed to show the title
+const route = useRoute();
 </script>
 
 <template>
@@ -98,7 +102,7 @@ const drawer = ref(true)
           <v-app-bar-nav-icon variant="text" @click="drawer = !drawer"></v-app-bar-nav-icon>
         </div>
 
-        <v-toolbar-title class="font-weight-medium">Accountbeheer</v-toolbar-title>
+        <v-toolbar-title class="font-weight-medium">{{ route.name }}</v-toolbar-title>
 
         <v-spacer></v-spacer>
 

--- a/web/src/router/index.ts
+++ b/web/src/router/index.ts
@@ -1,7 +1,6 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import LoginScreen from "@/views/LoginScreen.vue";
 import MainLayout from "@/layouts/MainLayout.vue";
-import HelloWorld from "@/views/HelloWorld.vue";
 
 const routes = [
   {
@@ -10,10 +9,12 @@ const routes = [
   },
   {
     path: '/dashboard',
+    name: 'dashboard',
     component: MainLayout,
     children: [
       {
         path: 'example',
+        name: 'exampleTitle',
         component: MainLayout,
       },
     ]


### PR DESCRIPTION
Dit matcht issue #55 

Vanaf nu kan de top bar van de main layout dynamisch titels tonen.
![rt](https://user-images.githubusercontent.com/109791839/224475757-4b0d065c-9963-4cdd-a021-8276534369ad.png)
Hier matcht de titel met de route, maar men kan eender welke titel zetten voor een gegeven route. Dit doet men alsvolgd:

In het bestand `/web/src/router/index.ts` staan de routes gedefinieërd. Bij het toevoegen van een nieuwe route plaatst men in het `name` veld de naam van de titel voor deze route.

```ts
const routes = [
  {
    path: '/',
    component: LoginScreen,
  },
  {
    path: '/dashboard',
    name: 'dashboard',
    component: MainLayout,
    children: [
      {
        path: 'example',
        name: 'exampleTitle',
        component: MainLayout,
      },
    ]
  }
]
```