### PR TITLE
Documentatie: Link wiki vanuit README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,5 @@ Software Engineering Lab II (2022 - 2023)
 - `server`: Configuratiebestanden van servertoepassingen
 - `web`: Webapplicatie
 
+## Documentatie
+De documentatie van deze monorepo is beschikbaar in de bijhorende [wiki](https://github.com/SELab-2/Dr-Trottoir-1/wiki).


### PR DESCRIPTION
Het is nodig dat de algmene [README](https://github.com/SELab-2/Dr-Trottoir-1/blob/documentatie/feature/link-wiki-from-readme/README.md) van dit project een link bevat naar de wiki van dit project. Dit is wat er in deze PR gedaan is.