### PR TITLE
Frontend: Planningsoverzicht layout herwerking

### DIFF
--- a/web/src/views/SchedulingScreenStudents.vue
+++ b/web/src/views/SchedulingScreenStudents.vue
@@ -11,8 +11,6 @@
       <v-chip label prepend-icon="mdi-calendar-month-outline" variant="text">
         {{ day.rounds[0].deadline.getDate() }}
         {{ formatter.format(day.rounds[0].deadline) }}
-        
-  
       </v-chip>
     </template>
     <!-- Round cards -->
@@ -71,25 +69,25 @@
 
     <!-- Popup message containing detailed info about account creation. Will pop up when clicked on the text in the bottom div -->
     <v-overlay v-model="snackbar">
-    <v-snackbar v-model="snackbar" timeout="-1" elevation="24" color="white">
-      <v-card prepend-icon="mdi-exclamation" variant="flat">
-        <template v-slot:title> Start ronde </template>
-        <p class="mx-3">
-          Je staat op het punt een ronde te starten. Het huidige tijdstip zal
-          opgeslagen worden als start tijdstip. Ben je zeker dat je de ronde
-          wilt starten?
-        </p>
-        <div class="d-flex flex-row-reverse ma-3">
-          <router-link to="/rondes/detail">
-            <v-btn color="success"> Start ronde </v-btn>
-          </router-link>
+      <v-snackbar v-model="snackbar" timeout="-1" elevation="24" color="white">
+        <v-card prepend-icon="mdi-exclamation" variant="flat">
+          <template v-slot:title> Start ronde </template>
+          <p class="mx-3">
+            Je staat op het punt een ronde te starten. Het huidige tijdstip zal
+            opgeslagen worden als start tijdstip. Ben je zeker dat je de ronde
+            wilt starten?
+          </p>
+          <div class="d-flex flex-row-reverse ma-3">
+            <router-link to="/rondes/detail">
+              <v-btn color="success"> Start ronde </v-btn>
+            </router-link>
 
-          <v-btn @click="snackbar = false" color="error" class="mr-3">
-            Annuleer
-          </v-btn>
-        </div>
-      </v-card>
-    </v-snackbar>
+            <v-btn @click="snackbar = false" color="error" class="mr-3">
+              Annuleer
+            </v-btn>
+          </div>
+        </v-card>
+      </v-snackbar>
     </v-overlay>
   </v-card>
 </template>
@@ -98,7 +96,7 @@
 import { ref } from "vue";
 
 // https://stackoverflow.com/questions/1643320/get-month-name-from-date
-const formatter = new Intl.DateTimeFormat('nl', { month: 'long' });
+const formatter = new Intl.DateTimeFormat("nl", { month: "long" });
 
 const snackbar = ref(false);
 


### PR DESCRIPTION
closes #141 

De onderste kaarten zijn nu niet meer zichtbaar waardoor er geen kaarten meer op kaarten liggen. De datum is toegevoegd.
![planning](https://user-images.githubusercontent.com/109791839/227543453-751272bf-69cd-4f97-9bec-55eb095a4ede.png)
![planning_start](https://user-images.githubusercontent.com/109791839/227543458-dc849eec-b840-4b7d-ae10-422f9cde08c0.png)
