### PR TITLE
Frontend: Add Button component

### DIFF
--- a/web/src/components/AddButton.vue
+++ b/web/src/components/AddButton.vue
@@ -1,12 +1,18 @@
 <template>
-  <v-btn :icon='icon' color='primary' class='addButton' :size='size' id="menu-activator"/>
-  <v-menu activator="#menu-activator" location='top'>
+  <v-btn
+    :icon="icon"
+    color="primary"
+    class="addButton"
+    :size="size"
+    id="menu-activator"
+  />
+  <v-menu activator="#menu-activator" location="top">
     <v-list>
       <v-list-item
         v-for="(item, index) in items"
         :key="index"
         :value="index"
-        @click='item.clicked'
+        @click="item.clicked"
       >
         <v-list-item-title>{{ item.title }}</v-list-item-title>
       </v-list-item>
@@ -22,7 +28,7 @@ const props = defineProps({
     type: String,
     default: "x-large",
   },
-  items: Array
+  items: Array,
 });
 </script>
 
@@ -33,4 +39,3 @@ const props = defineProps({
   right: 20px;
 }
 </style>
-

--- a/web/src/components/ImageCard.vue
+++ b/web/src/components/ImageCard.vue
@@ -1,7 +1,7 @@
 <template>
   <img v-if="img" alt="imagecard" class="image" :src="img" />
   <v-card v-else class="image">
-    <v-card-item class='textcard'>
+    <v-card-item class="textcard">
       <div style="display: flex; justify-content: center">
         <v-icon v-if="titleIcon" color="#333333" :icon="titleIcon"></v-icon>
         <h3 v-if="title">{{ title }}</h3>

--- a/web/src/layouts/MainLayout.vue
+++ b/web/src/layouts/MainLayout.vue
@@ -5,7 +5,7 @@
         :temporary="!permanentDrawer"
         :permanent="!!permanentDrawer"
         v-model="drawer"
-        class='sidebar'
+        class="sidebar"
       >
         <v-list density="compact" nav>
           <v-list-item lines="two" @click="showAccount = !showAccount">
@@ -218,7 +218,6 @@ function onResize() {
   permanentDrawer.value = window.innerWidth > threasholdWidth;
 }
 window.addEventListener("resize", onResize);
-
 </script>
 
 <style lang="scss">
@@ -235,7 +234,7 @@ a {
   display: flex;
 }
 
-.sidebar{
+.sidebar {
   position: fixed !important;
   height: 100vh !important;
 }

--- a/web/src/views/BuildingScreen.vue
+++ b/web/src/views/BuildingScreen.vue
@@ -18,7 +18,9 @@
         <v-col class="schedule-date" cols="3" />
         <v-col>
           <v-card class="schedule-action d-flex">
-            <p class="me-auto" style="font-weight: 500; font-size: 22px">REST</p>
+            <p class="me-auto" style="font-weight: 500; font-size: 22px">
+              REST
+            </p>
             <p>07u45</p>
           </v-card>
         </v-col>
@@ -31,7 +33,9 @@
         </v-col>
         <v-col>
           <v-card class="schedule-action d-flex">
-            <p class="me-auto" style="font-weight: 500; font-size: 22px">GLAS</p>
+            <p class="me-auto" style="font-weight: 500; font-size: 22px">
+              GLAS
+            </p>
             <p>08u10</p>
           </v-card>
         </v-col>
@@ -91,7 +95,7 @@
       </div>
     </div>
   </div>
-  <AddButton icon='mdi-plus' :items='actions'/>
+  <AddButton icon="mdi-plus" :items="actions" />
 </template>
 
 <script lang="ts" setup>
@@ -99,7 +103,7 @@ import { ref } from "vue";
 import BuildingData from "@/components/BuildingData.vue";
 import RoundedButton from "@/components/RoundedButton.vue";
 import ImageCard from "@/components/ImageCard.vue";
-import AddButton from '@/components/AddButton.vue'
+import AddButton from "@/components/AddButton.vue";
 
 // reactive state to show the drawer or not
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -142,25 +146,24 @@ const comments = ref<Array<{ title: String; comment: String }>>([
   },
 ]);
 
-function foto(){
+function foto() {
   console.log("foto");
 }
 
-function opmerking(){
+function opmerking() {
   console.log("opmerking");
 }
 
 const actions = [
   {
     title: "Foto toevoegen",
-    clicked: foto
+    clicked: foto,
   },
   {
     title: "Opmerking toevoegen",
-    clicked: opmerking
-  }
-]
-
+    clicked: opmerking,
+  },
+];
 </script>
 
 <style scoped lang="scss">


### PR DESCRIPTION
Closes #146.
Deze PR implementeerd de add-button component zoals we die besproken hebben. Voorlopig is deze altijd zichtbaar maar we kunnen die ook enkel op kleine schermen tonen.
![image](https://user-images.githubusercontent.com/91731084/227574150-71ead637-8ff7-4dc3-a18f-337623d052ca.png)
![image](https://user-images.githubusercontent.com/91731084/227574216-2e32402c-e8a2-4aeb-8d55-3993dc06216a.png)
Voorlopig is de menu ook een simpele menu zonder al te veel styling. We kunnen later bekijken hoe we dit precies willen aanpakken maar ik vind dit alvast een goede start.
Verder heb ik de imagecards in deze PR herwerkt naar v-cards voor een beter samenhangende layout.
![image](https://user-images.githubusercontent.com/91731084/227574914-b4d5a1f2-d9f8-4590-8b63-e4d2c8999c6f.png)
![image](https://user-images.githubusercontent.com/91731084/227574974-c8241dd6-4b08-46c8-aa0b-0eed3f571bf4.png)
Ook is er nog een extra kleine change dat de sidebar nu een fixed position krijgt waardoor de footer altijd zichtbaar wordt.
![image](https://user-images.githubusercontent.com/91731084/227575153-40dbab4f-0b04-430a-9e96-53b83bed2864.png)
