### PR TITLE
Frontend: spellingsfout + opschonen 'contacteer ons'

### DIFF
--- a/web/src/views/LoginScreen.vue
+++ b/web/src/views/LoginScreen.vue
@@ -34,7 +34,9 @@
           </span>
         </p>
         <!-- Login button -->
-        <v-btn prepend-icon="mdi-login" color="success" to="/planning">Login</v-btn>
+        <v-btn prepend-icon="mdi-login" color="success" to="/planning"
+          >Login</v-btn
+        >
       </div>
     </div>
   </div>


### PR DESCRIPTION
closes #150 

De problemen zoals beschereven in de issue zijn aangepakt.
De login button was ook gewrapt in een `router-link`, maar dit is nu aangepast naar het `to=` veld in de button zelf.

![login](https://user-images.githubusercontent.com/109791839/227708254-59ef7fef-caab-4101-ba4a-2f2f118cc8b3.png)
