### PR TITLE
Docs: Info over `orm` en `docs` voor ontwikkelaars

### DIFF
--- a/mock/README.md
+++ b/mock/README.md
@@ -1,0 +1,15 @@
+# Mock data
+
+In deze subdirectory vind je een Node.js script om een PostgreSQL database in te vullen met mock data.
+
+```shell
+# Wijs het script naar de juiste database
+cp example.env .env
+$EDITOR .env
+
+# Installeer dependencies
+npm install
+
+# Voer een iteratie van toevoegingen uit
+npm run start
+```

--- a/orm/README.md
+++ b/orm/README.md
@@ -8,27 +8,29 @@ De database wordt beheerd aan de hand van PrismaORM. We definiëren het schema i
 npx prisma db push
 ```
 
-## Mock data
+## Artifacts
 
-We voorzien een script om tijdens het ontwikkelen de database in te vullen met willekeurige data.
+Prisma genereert types en klassen om *type safe* queries uit te voeren. Hieruit volgt dat iedere module die hier gebruik van wenst te maken dient te beschikken over de corresponderende TypeScript bestanden. We publiceren deze als `@selab-2/groep-1-orm` in de GitHub NPM package registry. Maak je wijzigingen in `schema.prisma`, dan dien je dus een nieuwe package te publiceren.
 
 ```shell
-# Installeer dependencies
-npm install
+# Verhoog de huidige PATCH versie
+$EDITOR package.json
 
-# Geneer de PrismaORM types
+# Genereer de nieuwe Prisma artifacts
 npx prisma generate
 
-# Voer een iteratie van toevoegingen uit
-npm run start
+# Publiceer naar de package registry
+npm publish
+```
+
+De nieuwste versie kan je eender waar downloaden met
+
+```shell
+npm install @selab-2/groep-1-orm@MAJOR.MINOR.PATCH
 ```
 
 ## Design
 
-De relaties tussen de verschillende entteiten wordt hieronder gegeven. Merk echter op dat deze niet noodzakelijk finaal zijn. Voor meer informatie, zie `./prisma/schema.prisma`
+De relaties tussen de verschillende enteiten wordt hieronder gegeven. Merk echter op dat deze niet noodzakelijk finaal zijn. Voor meer informatie, zie `./prisma/schema.prisma`
 
 ![](../orm/Logisch_ontwerp.png)
-
-## Deployment
-
-We voorzien een PostgreSQL database in de `server/docker-compose.yml` stack. Zie `server/README.md` voor meer informatie.


### PR DESCRIPTION
Beperkte uitbreiding van de documentatie i.v.m. `npm publish` en de mockgenerator.

Closes #158