### PR TITLE
API: Syndicus informatie in het `User` veld voor autorisatie

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@selab-2/groep-1-orm": "^1.0.8",
+        "@selab-2/groep-1-orm": "^1.0.9",
         "@types/date-arithmetic": "^4.1.1",
         "@types/passport": "^1.0.12",
         "compression": "^1.7.4",
@@ -1310,12 +1310,13 @@
       "integrity": "sha512-3Vd8Qq06d5xD8Ch5WauWcUUrsVPdMC6Ge8ILji8RFfyhUpqon6qSyGM0apvr1O8n8qH8cKkEFqRPsYjuz5r83g=="
     },
     "node_modules/@selab-2/groep-1-orm": {
-      "version": "1.0.8",
-      "resolved": "https://npm.pkg.github.com/download/@selab-2/groep-1-orm/1.0.8/adb33509a2deb4ab817676e281a6a9f0d5dbcf92",
-      "integrity": "sha512-VACYC9YBqYnqS3ac2O8Gr5SW/S9ZjFvycFi2I1hrboaVPxgR4VbRbk7Y9plUbU7z97Upybt2C1EE2BI47gYgKQ==",
+      "version": "1.0.9",
+      "resolved": "https://npm.pkg.github.com/download/@selab-2/groep-1-orm/1.0.9/1d6f8c36256c893cfde4c03e7bb5434344d2b09f",
+      "integrity": "sha512-SB4BiY1PJnysrRR1v5bGoj07WZghLH5VsfxFMDCzxii8LHjyMgfWhrku7HZ5F8mEcaYrunTtM5avUI2LENWrMQ==",
       "license": "ISC",
       "dependencies": {
-        "@prisma/client": "^4.11.0"
+        "@prisma/client": "^4.11.0",
+        "dotenv": "^16.0.3"
       }
     },
     "node_modules/@sinclair/typebox": {

--- a/api/package.json
+++ b/api/package.json
@@ -7,7 +7,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@selab-2/groep-1-orm": "^1.0.8",
+    "@selab-2/groep-1-orm": "^1.0.9",
     "@types/date-arithmetic": "^4.1.1",
     "@types/passport": "^1.0.12",
     "compression": "^1.7.4",

--- a/api/src/types/index.d.ts
+++ b/api/src/types/index.d.ts
@@ -1,15 +1,29 @@
-import { User } from "@prisma/client";
+import { Address } from "@selab-2/groep-1-orm";
 
-type PrismaUser = User;
+export type SerializableUser = {
+    id: number;
+    email: string;
+    first_name: string;
+    last_name: string;
+    last_login: Date;
+    date_added: Date;
+    phone: string;
+    address_id: number;
+    student: boolean;
+    super_student: boolean;
+    admin: boolean;
+    address: Address;
+    syndicus: Array<{ id: number }>;
+};
 
 export {};
 
 declare global {
     namespace Express {
         export interface Request {
-            user: PrismaUser | null;
+            user: SerializableUser | null;
         }
 
-        export type User = PrismaUser;
+        export type User = SerializableUser;
     }
 }

--- a/orm/package.json
+++ b/orm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@selab-2/groep-1-orm",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Package containing the PrismaORM types of our database schema.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/orm/prisma/schema.prisma
+++ b/orm/prisma/schema.prisma
@@ -51,7 +51,7 @@ model User {
 
     // Relaties
     regions         UserRegion[]
-    Syndicus        Syndicus[]
+    syndicus        Syndicus[]
     schedule        Schedule[]
     uploaded_images Image[]
 


### PR DESCRIPTION
We voorzien een veld `syndicus: Array<{ id: number}>` in `express.Request.user` om eenvoudig na te gaan of een gebruiker de syndicus is van een gegeven gebouw. We definiëren hiervoor een nieuw type `SerializableUser`, die aangeeft hoe Passport.js intern de gebruiker voorstelt. Dit is gelijk aan `Prisma::User`, min `halt` en `salt`.

```json
{
  "id": 7,
  "email": "jens.pots@ugent.be",
  "first_name": "Jens",
  "last_name": "Pots",
  "last_login": "2023-01-01T00:00:00.000Z",
  "date_added": "2020-01-01T00:00:00.000Z",
  "phone": "phone number",
  "address_id": 10,
  "student": false,
  "super_student": true,
  "admin": true,
  "address": {
    "id": 10,
    "street": "Bahiho Road",
    "number": 62,
    "city": "Gent",
    "zip_code": 4044,
    "latitude": -27.92709,
    "longitude": -153.61918
  },
  "syndicus": [
    {
      "id": 38
    }
  ]
}
```

Closes #186.