### PR TITLE
API: Throw exception over return values

### DIFF
--- a/api_query/src/api_error.ts
+++ b/api_query/src/api_error.ts
@@ -1,4 +1,0 @@
-export type APIError = {
-    code: number;
-    message: string;
-};

--- a/api_query/src/index.ts
+++ b/api_query/src/index.ts
@@ -1,5 +1,4 @@
 import { ActionQuery } from "./action";
-import { APIError } from "./api_error";
 import { BuildingQuery } from "./building";
 import { GarbageQuery } from "./garbage";
 import { ProgressQuery } from "./progress";
@@ -9,10 +8,10 @@ import { ScheduleQuery } from "./schedule";
 import { SyndicusQuery } from "./syndicus";
 import { UserQuery } from "./user";
 import { UserRegionQuery } from "./user_region";
+import { QueryError } from "./query_error";
 
 export {
     ActionQuery,
-    APIError,
     BuildingQuery,
     GarbageQuery,
     ProgressQuery,
@@ -22,4 +21,5 @@ export {
     SyndicusQuery,
     UserQuery,
     UserRegionQuery,
+    QueryError,
 };

--- a/api_query/src/query_error.ts
+++ b/api_query/src/query_error.ts
@@ -1,0 +1,14 @@
+/**
+ * Modeleert een HTTP error. Wordt opgegooid indien er een fout optreedt tijdens
+ * het verkrijgen van de resultaten.
+ */
+export class QueryError extends Error {
+    code: number;
+    message: string;
+
+    constructor(code: number, message: string) {
+        super();
+        this.code = code;
+        this.message = message;
+    }
+}


### PR DESCRIPTION
In deze kleine PR wijzigen we de werking van de query builder zodanig dat deze een `QueryError` opgooit bij fouten, in plaats van het teruggeven van een error object. Hierdoor is de *error handling* een stuk eenvoudiger in onze webapplicatie.

Omdat de `fetch` code een heel stuk uitgebreider is, introduceren we de nieuwe methode `Query::fetchJSON`.

```typescript
private async fetchJSON(url: string, method = "GET"): Promise<any | null> {
    let res: Response | null = null;
    let json: any = null;

    try {
        res = await fetch(url, {
            method: method,
            headers: {
                "Accept": "application/json",
                "Content-Type": "application/json",
            },
            credentials: "include",
            redirect: "error",
        });
    } catch (e) {
        throw new QueryError(503, "Service Unavailable");
    }

    try {
        json = await res.json();
    } catch (e) {
        throw new QueryError(500, "Internal Server Error");
    }

    if (!res.ok) {
        throw new QueryError(res.status, json["message"] ?? "Unknown");
    }

    return json;
}
```

Closes #216.