### PR TITLE
garbage scheduling remake

### DIFF
--- a/web/src/components/table/Header.ts
+++ b/web/src/components/table/Header.ts
@@ -31,7 +31,7 @@ export class Header<T> {
   }
 
   // Action to perform when clicked on.
-  onClick: ((e: T) => void) | null = null;
+  onClick: (e: T, list: Array<T | null>) => void = () => {};
 
   // TODO: replace with API call.
   // Sorts an array of T's using this specific field.

--- a/web/src/components/table/Table.vue
+++ b/web/src/components/table/Table.vue
@@ -24,7 +24,7 @@
         </th>
       </tr>
     </thead>
-    <tbody>
+    <tbody v-if="entries">
       <tr v-for="item in entries?.filter((e) => e !== null)" :key="item.id">
         <td
           v-bind:key="header.id"
@@ -60,7 +60,7 @@
             variant="plain"
             v-bind:icon="header.get(item)"
             size="small"
-            @click="() => header.onClick(item)"
+            @click="() => header.onClick(item, entries!)"
           ></v-btn>
           <p v-if="header.type === RowType.TEXT">
             {{ header.get(item) }}
@@ -110,7 +110,6 @@ function sort(header: Header<any>) {
 </script>
 
 <style lang="sass" scoped>
-
 .clickable
   cursor: pointer
 

--- a/web/src/router/index.ts
+++ b/web/src/router/index.ts
@@ -115,7 +115,7 @@ const routes = [
         },
       },
       {
-        path: "/vuilnis/plannen",
+        path: "/gebouw/:id/afvalschema",
         name: "garbage_plan",
         component: GarbageMaker,
       },

--- a/web/src/types/GarbageTable.ts
+++ b/web/src/types/GarbageTable.ts
@@ -1,0 +1,70 @@
+import { TableEntity } from "@/components/table/TableEntity";
+import { Header } from "@/components/table/Header";
+import { RowType } from "@/components/table/RowType";
+
+export interface DetailedDay {
+  id: number;
+  date: Date;
+  garbageType: string;
+  action: string;
+  time: string;
+}
+
+export class GarbageTable extends TableEntity<DetailedDay> {
+  static headers(): Array<Header<DetailedDay>> {
+    return [
+      {
+        id: 0,
+        name: "Day",
+        fit: false,
+        get: (e: DetailedDay) => e.date.toLocaleDateString(),
+        type: RowType.TEXT,
+        sortable: false,
+      },
+      {
+        id: 1,
+        name: "Type",
+        fit: false,
+        get: (e: DetailedDay) => e.garbageType,
+        type: RowType.TEXT,
+        sortable: false,
+      },
+      {
+        id: 2,
+        name: "Actie",
+        fit: false,
+        get: (e: DetailedDay) => e.action,
+        type: RowType.TEXT,
+        sortable: false,
+      },
+      {
+        id: 3,
+        name: "Tijd",
+        fit: false,
+        get: (e: DetailedDay) => e.time,
+        type: RowType.TEXT,
+        sortable: false,
+      },
+      {
+        id: 4,
+        name: "",
+        fit: true,
+        get: () => "mdi-close",
+        type: RowType.ICONBUTTON,
+        sortable: false,
+        onClick: (e: DetailedDay, list: Array<DetailedDay | null>) => {
+          const index = list.findIndex((x) => x === e);
+          list[index] = null;
+        },
+      },
+    ].map((e) => new Header<DetailedDay>(e));
+  }
+
+  headers(): Array<Header<DetailedDay>> {
+    return GarbageTable.headers();
+  }
+
+  route(): string {
+    throw new Error("Method not implemented.");
+  }
+}

--- a/web/src/views/building/GarbageMaker.vue
+++ b/web/src/views/building/GarbageMaker.vue
@@ -1,59 +1,67 @@
 <template>
   <div>
-    <HFillWrapper margin="mx-4">
-      <v-row>
-        <v-col>
-          <v-select
-            v-model="garbageType"
-            :items="garbageTypes"
-            label="Garbage Type"
-          ></v-select>
-        </v-col>
-        <v-col>
-          <v-select v-model="action" :items="actions" label="Actie"></v-select>
-        </v-col>
-      </v-row>
+    <HFillWrapper margin="mx-4 mb-4">
+      <v-btn
+        size="small"
+        class="mb-4"
+        prepend-icon="mdi-arrow-left"
+        variant="tonal"
+        >Keer terug</v-btn
+      >
 
-      <v-row>
-        <v-col>
-          <v-select
-            v-model="frequency"
-            :items="frequencys"
-            label="Frequentie"
-          ></v-select>
-        </v-col>
-        <v-col>
-          <v-text-field
-            v-model="startDate"
-            label="Start Datum"
-            type="date"
-          ></v-text-field>
-        </v-col>
-        <v-col v-if="frequency !== 'enkel'">
-          <v-text-field
-            v-model="endDate"
-            v-if="frequency !== 'enkel'"
-            label="Einde Datum"
-            type="date"
-          ></v-text-field>
-        </v-col>
-        <v-col>
-          <v-text-field v-model="time" label="Tijd" type="time"></v-text-field>
-        </v-col>
-      </v-row>
+      <h2>Afvalkalender</h2>
 
-      <div class="d-flex flex-row-reverse">
+      <p class="mb-4">
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat. Duis aute irure dolor in reprehenderit in voluptate
+        velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
+        occaecat cupidatat non proident, sunt in culpa qui officia deserunt
+        mollit anim id est laborum.
+      </p>
+
+      <div class="flex">
+        <v-select
+          v-model="garbageType"
+          :items="garbageTypes"
+          label="Garbage Type"
+        ></v-select>
+        <v-select v-model="action" :items="actions" label="Actie"></v-select>
+        <v-select
+          v-model="frequency"
+          :items="frequenties"
+          label="Frequentie"
+        ></v-select>
+      </div>
+
+      <div class="flex">
+        <v-text-field
+          v-model="startDate"
+          label="Start Datum"
+          type="date"
+        ></v-text-field>
+        <v-text-field
+          v-model="endDate"
+          v-if="frequency !== 'enkel'"
+          label="Einde Datum"
+          type="date"
+        ></v-text-field>
+        <v-text-field v-model="time" label="Tijd" type="time"></v-text-field>
+      </div>
+
+      <div class="flex">
         <v-btn
-          class="mx-1"
-          variant="plain"
+          prepend-icon="mdi-check"
+          variant="tonal"
           @click="submit"
           :disabled="detailedDays.length === 0"
           >Inplannen</v-btn
         >
         <v-btn
-          class="mx-1"
+          prepend-icon="mdi-plus-circle"
           @click="add"
-          variant="plain"
+          variant="tonal"
           :disabled="
             garbageType === undefined ||
             action === undefined ||
@@ -63,40 +71,15 @@
           "
           >Toevoegen</v-btn
         >
-        <v-btn variant="plain" @click="clearAll">Alles verwijderen</v-btn>
+        <v-btn prepend-icon="mdi-delete" variant="tonal" @click="clearAll"
+          >Alles verwijderen</v-btn
+        >
       </div>
-
-      <v-slide-group class="pt-4" show-arrows>
-        <v-slide-group-item v-for="schedule in summary" :key="schedule.id">
-          <v-card color="grey-lighten-1" variant="flat" class="mx-1">
-            <template v-slot:title> {{ schedule.garbageType }}</template>
-            <template v-slot:append>
-              <v-icon
-                color="red"
-                @click="deleteSummary(schedule.id)"
-                icon="mdi-close"
-              />
-            </template>
-            <div class="pa-4">
-              <div><strong>Actie:</strong> {{ schedule.action }}</div>
-              <div>
-                <strong>Start:</strong> {{ schedule.start.toDateString() }}
-              </div>
-              <div>
-                <strong>Einde:</strong> {{ schedule.end.toDateString() }}
-              </div>
-              <div><strong>Type:</strong> {{ schedule.garbageType }}</div>
-              <div><strong>Actie:</strong> {{ schedule.action }}</div>
-              <div><strong>Tijd:</strong> {{ schedule.time }}</div>
-            </div>
-          </v-card>
-        </v-slide-group-item>
-      </v-slide-group>
     </HFillWrapper>
 
     <Table
       v-bind:entries="detailedDays"
-      v-bind:headers="ScheduleTable.headers()"
+      v-bind:headers="GarbageTable.headers()"
     ></Table>
   </div>
 </template>
@@ -104,92 +87,14 @@
 <script lang="ts" setup>
 import { ref } from "vue";
 import HFillWrapper from "@/layouts/HFillWrapper.vue";
-import { TableEntity } from "@/components/table/TableEntity";
-import { Header } from "@/components/table/Header";
-import { RowType } from "@/components/table/RowType";
 import Table from "@/components/table/Table.vue";
-
-interface Schedule {
-  id: number;
-  start: Date;
-  end: Date;
-  garbageType: string;
-  action: string;
-  time: string;
-  frequency: string;
-}
-
-interface DetailedDay {
-  id: number;
-  scheduleId: number;
-  date: Date;
-  garbageType: string;
-  action: string;
-  time: string;
-}
-
-class ScheduleTable extends TableEntity<DetailedDay> {
-  static headers(): Array<Header<DetailedDay>> {
-    return [
-      {
-        id: 0,
-        name: "Day",
-        fit: false,
-        get: (e: DetailedDay) => e.date.toLocaleDateString(),
-        type: RowType.TEXT,
-        sortable: false,
-      },
-      {
-        id: 1,
-        name: "Type",
-        fit: false,
-        get: (e: DetailedDay) => e.garbageType,
-        type: RowType.TEXT,
-        sortable: false,
-      },
-      {
-        id: 2,
-        name: "Actie",
-        fit: false,
-        get: (e: DetailedDay) => e.action,
-        type: RowType.TEXT,
-        sortable: false,
-      },
-      {
-        id: 3,
-        name: "Tijd",
-        fit: false,
-        get: (e: DetailedDay) => e.time,
-        type: RowType.TEXT,
-        sortable: false,
-      },
-      {
-        id: 4,
-        name: "",
-        fit: true,
-        get: () => "mdi-close",
-        type: RowType.ICONBUTTON,
-        sortable: false,
-        onClick: (e: DetailedDay) => {
-          const index = detailedDays.value.findIndex((x) => x === e);
-          detailedDays.value[index] = null;
-        },
-      },
-    ].map((e) => new Header<DetailedDay>(e));
-  }
-
-  headers(): Array<Header<DetailedDay>> {
-    return ScheduleTable.headers();
-  }
-
-  route(): string {
-    throw new Error("Method not implemented.");
-  }
-}
+import { DetailedDay } from "@/types/GarbageTable";
+import { GarbageTable } from "@/types/GarbageTable";
 
 const garbageTypes = ["REST", "PMD", "GFT", "Papier"];
 const actions = ["buiten zetten", "binnen halen"];
-const frequencys = ["enkel", "wekelijks", "tweewekelijks", "maandelijks"];
+const frequenties = ["enkel", "wekelijks", "tweewekelijks", "maandelijks"];
+
 const frequencyDict: Record<string, number> = {
   enkel: 1,
   wekelijks: 7,
@@ -203,21 +108,8 @@ const startDate = ref("");
 const endDate = ref("");
 const time = ref("");
 const frequency = ref<string>("wekelijks");
+const detailedDays = ref<Array<DetailedDay | null>>([]);
 
-//nu nog een string voor het simple te houden
-const summary = ref<Array<Schedule>>([]);
-const detailedDays = ref<Array<DetailedDay | null>>([
-  {
-    action: "TEST",
-    date: new Date(),
-    garbageType: "GFT",
-    scheduleId: 1,
-    time: "20u",
-    id: 1,
-  },
-]);
-
-let scheduleCounter = 0;
 let dayCounter = 0;
 
 function add() {
@@ -225,26 +117,13 @@ function add() {
     endDate.value = startDate.value;
   }
 
-  const scheduleSummary: Schedule = {
-    id: scheduleCounter,
-    start: new Date(startDate.value),
-    end: new Date(endDate.value),
-    garbageType: garbageType.value!,
-    action: action.value!,
-    time: time.value,
-    frequency: frequency.value,
-  };
-  summary.value.push(scheduleSummary);
-
-  // Calculate all separate days
   const start = new Date(startDate.value);
   const end = new Date(endDate.value);
   let frequencyCount = frequencyDict[frequency.value];
-  //elke dag berekenen afhankelijk van de frequentie
-  for (let d = start; d <= end; d.setDate(d.getDate() + frequencyCount)) {
+
+  for (const d = start; d <= end; d.setDate(d.getDate() + frequencyCount)) {
     detailedDays.value.push({
       id: dayCounter++,
-      scheduleId: scheduleCounter,
       date: new Date(d),
       garbageType: garbageType.value!,
       action: action.value!,
@@ -252,27 +131,11 @@ function add() {
     });
   }
 
-  scheduleCounter++;
-
   garbageType.value = undefined;
   action.value = undefined;
   startDate.value = "";
   endDate.value = "";
   time.value = "";
-}
-
-function deleteSummary(id: number) {
-  const correspondingSummary = summary.value.find(
-    (schedule) => schedule.id === id,
-  ) as Schedule;
-  if (correspondingSummary) {
-    for (const i in detailedDays.value) {
-      if (detailedDays.value[i]?.scheduleId === id) {
-        detailedDays.value[i] = null;
-      }
-    }
-  }
-  summary.value = summary.value.filter((schedule) => schedule.id !== id);
 }
 
 function submit() {
@@ -284,7 +147,11 @@ function clearAll() {
   while (detailedDays.value.length > 0) {
     detailedDays.value.pop();
   }
-
-  summary.value = [];
 }
 </script>
+
+<style lang="sass">
+.flex
+  display: flex
+  gap: 20px
+</style>


### PR DESCRIPTION
Hiermee kunnen gebruikers afvalschedules inplannen. Gebruikers kunnen informatie invoeren over het afvaltype, actie, begin- en einddatum, tijd en frequentie van een schedule. De pagina toont een samenvatting van de ingevoerde schedules met behulp van slide-groep. Elke kaart kan verwijdert worden, bij het verwijderen van de kaart worden ook alle bijhoorden dagen verwijdert.  De pagina toont ook een tabel met gedetailleerde informatie over elke geplande dag, met een verwijder knop om afzonderlijke dagen te verwijderen. De pagina biedt knoppen voor het toevoegen van een schedule, het indienen van alle schedules en het wissen van alle schedules.



![image](https://user-images.githubusercontent.com/83694704/231484761-219b6679-0562-498d-b93e-afdc69438282.png)
