### PR TITLE
Frontend: Verander routes in de TableEntities

### DIFF
--- a/web/src/components/table/TableEntity.ts
+++ b/web/src/components/table/TableEntity.ts
@@ -13,5 +13,5 @@ export abstract class TableEntity<T> {
   /**
    * The route to follow when clicking on the row.
    */
-  abstract route(): { name: string, params: object };
+  abstract route(): { name: string; params: object };
 }

--- a/web/src/types/Building.ts
+++ b/web/src/types/Building.ts
@@ -2,7 +2,7 @@ import { Header } from "@/components/table/Header";
 import { TableEntity } from "@/components/table/TableEntity";
 import { RowType } from "@/components/table/RowType";
 import chance from "chance";
-import { formatDate } from '@/assets/scripts/date'
+import { formatDate } from "@/assets/scripts/date";
 
 export class Building implements TableEntity<Building> {
   id: number;
@@ -68,10 +68,10 @@ export class Building implements TableEntity<Building> {
     });
   }
 
-  route(): { name: string, params: { id: number, date: string } } {
+  route(): { name: string; params: { id: number; date: string } } {
     return {
-      name: 'building_id_detail',
+      name: "building_id_detail",
       params: { id: this.id, date: formatDate(new Date()) },
-    }
+    };
   }
 }

--- a/web/src/types/Round.ts
+++ b/web/src/types/Round.ts
@@ -2,7 +2,6 @@ import { Header } from "@/components/table/Header";
 import { TableEntity } from "@/components/table/TableEntity";
 import { RowType } from "@/components/table/RowType";
 import chance from "chance";
-import { formatDate } from '@/assets/scripts/date'
 
 export class Routes implements TableEntity<Routes> {
   id: number;
@@ -89,10 +88,10 @@ export class Routes implements TableEntity<Routes> {
     });
   }
 
-  route(): { name: string, params: { id: number } } {
+  route(): { name: string; params: { id: number } } {
     return {
-      name: 'round_detail',
+      name: "round_detail",
       params: { id: this.id },
-    }
+    };
   }
 }

--- a/web/src/types/User.ts
+++ b/web/src/types/User.ts
@@ -2,7 +2,6 @@ import { Header } from "@/components/table/Header";
 import { TableEntity } from "@/components/table/TableEntity";
 import { RowType } from "@/components/table/RowType";
 import chance from "chance";
-import { formatDate } from '@/assets/scripts/date'
 
 export class User implements TableEntity<User> {
   id: number;
@@ -78,11 +77,11 @@ export class User implements TableEntity<User> {
     });
   }
 
-  route(): { name: string, params: { id: number, isadmin: boolean } } {
+  route(): { name: string; params: { id: number; isadmin: boolean } } {
     return {
-      name: 'account_settings',
+      name: "account_settings",
       params: { id: this.id, isadmin: false },
-    }
+    };
     // TODO: remove :isadmin when auth is in frontend
   }
 }


### PR DESCRIPTION
De route-links in de TableEntities gebruiken nu route names in plaats van deze te hard-coderen. Ook linken ze nu naar de correcte pagina's.
Closes: #230