### PR TITLE
API: fix login crash

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -14,7 +14,6 @@
         "@selab-2/groep-1-query": "^1.0.12",
         "@vuepic/vue-datepicker": "^4.2.0",
         "chance": "^1.1.11",
-        "esbuild-windows-64": "^0.15.18",
         "pinia": "^2.0.33",
         "prettier": "^2.8.4",
         "roboto-fontface": "*",
@@ -2731,20 +2730,6 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild-windows-64": {
-      "version": "0.15.18",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.15.18.tgz",
-      "integrity": "sha512-qinug1iTTaIIrCorAUjR0fcBk24fjzEedFYhhispP8Oc7SFvs+XeW3YpAKiKp8dRpizl4YYAhxMjlftAMJiaUw==",
-      "cpu": [
-        "x64"
-      ],
-      "os": [
-        "win32"
       ],
       "engines": {
         "node": ">=12"

--- a/web/package.json
+++ b/web/package.json
@@ -17,7 +17,6 @@
     "@selab-2/groep-1-query": "^1.0.12",
     "@vuepic/vue-datepicker": "^4.2.0",
     "chance": "^1.1.11",
-    "esbuild-windows-64": "^0.15.18",
     "pinia": "^2.0.33",
     "prettier": "^2.8.4",
     "roboto-fontface": "*",


### PR DESCRIPTION
Ik heb gemerkt dat `api/src/passport.js` de gebruiker zocht via `prisma.user.findFirstOrThrow`. Het gooien van de error werd echter nergens opgevangen en ik vond zelf niet waar die opgevangen moet worden.
Dit heb ik dus vervangen door een gewone `prisma.user.findFirst`. Na het zoeken van de gebruiker controleer ik dan of deze null is via 
```typescript
if (user === null) {
   return cb(null, undefined);
}
```

Voor mij leek dit de beste manier, aangezien de frontend hierna sowieso de gebruiker probeert op te halen. Wanneer dat gebeurt, krijgt deze null terug en wordt de error `Unauthorized` opgevangen op de goede manier.
Ik zou mss wel in de frontend iets toevoegen om de gebruiker te laten weten dat de verkeerde email werd gebruikt. Anders krijgt de gebruiker geen melding en denkt die dat de site gwn niet werkt ofzo.

Closes #232 