### PR TITLE
Frontend: empty schedule

### DIFF
--- a/web/src/views/student/SchedulingScreenStudents.vue
+++ b/web/src/views/student/SchedulingScreenStudents.vue
@@ -191,7 +191,7 @@ const days = await tryOrAlertAsync<Array<DayEntry>>(async () => {
         schedule: scheduleItem.id,
       });
 
-      if (progress.length > 0) {
+      if (schedules.length > 0) {
         empty.value = false;
       }
 


### PR DESCRIPTION
De empty schedule tekst werd getoond terwijl er wel een planning was binnen de komende 3 dagen. Dit zou niet mogen.