### PR TITLE
API: extra testen voor route Garbage

### DIFF
--- a/api/__tests__/routes/garbage.test.ts
+++ b/api/__tests__/routes/garbage.test.ts
@@ -2,8 +2,7 @@ import { describe, test } from "@jest/globals";
 import { AuthenticationLevel, Testrunner } from "../utilities/Testrunner";
 import request from "supertest";
 import app from "../../src/main";
-import { resetDatabase } from "../mock/database";
-import { restoreTables } from "../mock/database";
+import { resetDatabase, restoreTables } from "../mock/database";
 import {
     badRequestForeignKey,
     badRequestResponse,
@@ -32,7 +31,12 @@ describe("Garbage tests", () => {
         beforeAll(() => {
             runner.authLevel(AuthenticationLevel.SUPER_STUDENT);
         });
-        test("GET /garbage", async () => {
+
+        describe("GET /garbage with different roles", async () => {
+            afterAll(() => {
+                runner.authLevel(AuthenticationLevel.SUPER_STUDENT);
+            });
+
             const expectedData = [
                 {
                     action: { description: "action 1", id: 1 },
@@ -82,12 +86,64 @@ describe("Garbage tests", () => {
                 },
             ];
 
-            await runner.get({
-                url: "/garbage",
-                expectedData: expectedData,
+            test("GET /garbage as a superstudent", async () => {
+                runner.authLevel(AuthenticationLevel.SUPER_STUDENT);
+
+                await runner.get({
+                    url: "/garbage",
+                    expectedData: expectedData,
+                });
+            });
+
+            test("GET /garbage as a student", async () => {
+                runner.authLevel(AuthenticationLevel.STUDENT);
+
+                await runner.get({
+                    url: "/garbage",
+                    expectedData: expectedData,
+                });
+            });
+
+            test("GET /garbage as a syndicus", async () => {
+                runner.authLevel(AuthenticationLevel.SYNDICUS);
+                const expectedData = [
+                    {
+                        action: { description: "action 1", id: 1 },
+                        action_id: 1,
+                        building: {
+                            address: {
+                                city: "Sydney",
+                                id: 1,
+                                latitude: -33.865143,
+                                longitude: 151.2099,
+                                number: 42,
+                                street: "Wallaby Way",
+                                zip_code: 2000,
+                            },
+                            deleted: false,
+                            id: 1,
+                            ivago_id: "ivago-1",
+                            description: "Description of building 1",
+                            name: "Building 1",
+                        },
+                        building_id: 1,
+                        id: 1,
+                        pickup_time: "2023-05-04T12:00:00.000Z",
+                    },
+                ];
+
+                await runner.get({
+                    url: "/garbage?syndicus_id=1",
+                    expectedData: expectedData,
+                });
             });
         });
-        test("GET /garbage/:id", async () => {
+
+        describe("GET /garbage/:id with different roles", async () => {
+            afterAll(() => {
+                runner.authLevel(AuthenticationLevel.SUPER_STUDENT);
+            });
+
             const expected = [
                 {
                     id: 1,
@@ -113,9 +169,29 @@ describe("Garbage tests", () => {
                     },
                 },
             ];
-            await runner.get({
-                url: "/garbage/1",
-                expectedData: expected,
+
+            test("GET /garbage/:id as superstudent", async () => {
+                runner.authLevel(AuthenticationLevel.SUPER_STUDENT);
+                await runner.get({
+                    url: "/garbage/1",
+                    expectedData: expected,
+                });
+            });
+
+            test("GET /garbage/:id as student", async () => {
+                runner.authLevel(AuthenticationLevel.STUDENT);
+                await runner.get({
+                    url: "/garbage/1",
+                    expectedData: expected,
+                });
+            });
+
+            test("GET /garbage/:id as syndicus", async () => {
+                runner.authLevel(AuthenticationLevel.SYNDICUS);
+                await runner.get({
+                    url: "/garbage/1",
+                    expectedData: expected,
+                });
             });
         });
 
@@ -232,6 +308,34 @@ describe("Garbage tests", () => {
             });
             test("Cannot use any path as Student except GET", async () => {
                 runner.authLevel(AuthenticationLevel.STUDENT);
+
+                await runner.post({
+                    url: "/garbage",
+                    data: garbage,
+                    expectedResponse: forbiddenResponse,
+                    statusCode: 403,
+                });
+
+                await runner.patch({
+                    url: "/garbage/1",
+                    data: garbage,
+                    expectedResponse: forbiddenResponse,
+                    statusCode: 403,
+                });
+
+                await runner.delete({
+                    url: "/garbage/1",
+                    statusCode: 403,
+                });
+            });
+            test("Cannot use any path as Syndicus except GET with syndicus_id", async () => {
+                runner.authLevel(AuthenticationLevel.SYNDICUS);
+
+                await runner.get({
+                    url: "/garbage",
+                    expectedData: [forbiddenResponse],
+                    statusCode: 403,
+                });
 
                 await runner.post({
                     url: "/garbage",

--- a/api/__tests__/routes/garbage.test.ts
+++ b/api/__tests__/routes/garbage.test.ts
@@ -32,7 +32,7 @@ describe("Garbage tests", () => {
             runner.authLevel(AuthenticationLevel.SUPER_STUDENT);
         });
 
-        describe("GET /garbage with different roles", async () => {
+        describe("GET /garbage with different roles", () => {
             afterAll(() => {
                 runner.authLevel(AuthenticationLevel.SUPER_STUDENT);
             });
@@ -139,7 +139,7 @@ describe("Garbage tests", () => {
             });
         });
 
-        describe("GET /garbage/:id with different roles", async () => {
+        describe("GET /garbage/:id with different roles", () => {
             afterAll(() => {
                 runner.authLevel(AuthenticationLevel.SUPER_STUDENT);
             });

--- a/api/__tests__/routes/garbage.test.ts
+++ b/api/__tests__/routes/garbage.test.ts
@@ -28,15 +28,11 @@ describe("Garbage tests", () => {
     });
 
     describe("Successful requests", () => {
-        beforeAll(() => {
+        beforeEach(() => {
             runner.authLevel(AuthenticationLevel.SUPER_STUDENT);
         });
 
         describe("GET /garbage with different roles", () => {
-            afterAll(() => {
-                runner.authLevel(AuthenticationLevel.SUPER_STUDENT);
-            });
-
             const expectedData = [
                 {
                     action: { description: "action 1", id: 1 },
@@ -140,10 +136,6 @@ describe("Garbage tests", () => {
         });
 
         describe("GET /garbage/:id with different roles", () => {
-            afterAll(() => {
-                runner.authLevel(AuthenticationLevel.SUPER_STUDENT);
-            });
-
             const expected = [
                 {
                     id: 1,

--- a/api/src/routes/garbage.ts
+++ b/api/src/routes/garbage.ts
@@ -21,6 +21,7 @@ export class GarbageRouting extends Routing {
         if (
             !req.user?.super_student &&
             !req.user?.admin &&
+            !req.user?.student &&
             req.user?.syndicus.every(
                 (element) =>
                     element.id !== Parser.number(req.query["syndicus_id"]),


### PR DESCRIPTION
## Beschrijving
Er zijn extra testen toegevoegd die de autorisatie van de syndicus nakijken:
- GET /building waarbij syndicus_id meegegeven wordt
- GET /building/:id
- alle andere requests die status 403 zouden moeten teruggeven

## Aanpassingen

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking wijziging met nieuwe functionaliteit)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] De code volgt de stijl en guidelines van dit project.
