### PR TITLE
Query: Correcte werking bij `instanceof`

### DIFF
--- a/api_query/__tests__/error.test.ts
+++ b/api_query/__tests__/error.test.ts
@@ -1,0 +1,8 @@
+import { QueryError } from "../src";
+
+describe("QueryError", () => {
+    it("", () => {
+        const e = new QueryError(200, "TEST");
+        expect(e instanceof QueryError).toBe(true);
+    });
+});

--- a/api_query/package-lock.json
+++ b/api_query/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@selab-2/groep-1-query",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@selab-2/groep-1-query",
-      "version": "1.0.19",
+      "version": "1.0.20",
       "license": "ISC",
       "dependencies": {
         "@selab-2/groep-1-orm": "^1.0.18"

--- a/api_query/src/query_error.ts
+++ b/api_query/src/query_error.ts
@@ -7,7 +7,8 @@ export class QueryError extends Error {
     message: string;
 
     constructor(code: number, message: string) {
-        super();
+        super(message);
+        Object.setPrototypeOf(this, QueryError.prototype);
         this.code = code;
         this.message = message;
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Beschrijving

Het prototype van `QueryError` wordt expliciet ingesteld voor een correcte werking met non `ES6` omgevingen te garanderen.

## Motivatie en context

Tot op heden werkte `QueryError` niet met de `instanceof` operator. Dit is nu opgelost.

## Testmethode

Er is een minieme test voorzien.

```typescript
describe("QueryError", () => {
    it("", () => {
        const e = new QueryError(200, "TEST");
        expect(e instanceof QueryError).toBe(true);
    });
});
```

## Screenshots (indien van toepassing):

Niet van toepassing.

## Aanpassingen

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking wijziging die een probleem oplost)
- New feature (non-breaking wijziging met nieuwe functionaliteit)
- Breaking change (bestaande functionaliteit breekt door deze aanpassingen)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] De code volgt de stijl en guidelines van dit project.
- Vereist een aanpassing aan de documentatie. 
- De documentatie is gewijzigd.

Closes #338.