### PR TITLE
Frontend: integrereren account knop in naam van gebruiker

### DIFF
--- a/web/src/layouts/MainLayout.vue
+++ b/web/src/layouts/MainLayout.vue
@@ -10,14 +10,17 @@
         color="background"
       >
         <v-list density="compact" nav>
-          <v-list-item lines="two" :to="{
-                name: 'account_settings',
-                params: { id: id },
-              }">
+          <v-list-item
+            lines="two"
+            :to="{
+              name: 'account_settings',
+              params: { id: id },
+            }"
+          >
             <template v-slot:prepend>
               <Avatar :name="studentName" />
             </template>
-            <div class="flex" >
+            <div class="flex">
               <div class="text">
                 <v-list-item-title>{{ studentName }}</v-list-item-title>
                 <v-list-item-subtitle v-if="useAuthStore()?.auth?.admin">

--- a/web/src/layouts/MainLayout.vue
+++ b/web/src/layouts/MainLayout.vue
@@ -10,11 +10,14 @@
         color="background"
       >
         <v-list density="compact" nav>
-          <v-list-item lines="two">
+          <v-list-item lines="two" :to="{
+                name: 'account_settings',
+                params: { id: id },
+              }">
             <template v-slot:prepend>
               <Avatar :name="studentName" />
             </template>
-            <div class="flex">
+            <div class="flex" >
               <div class="text">
                 <v-list-item-title>{{ studentName }}</v-list-item-title>
                 <v-list-item-subtitle v-if="useAuthStore()?.auth?.admin">
@@ -41,19 +44,6 @@
               title="Afmelden"
               value="logout"
             />
-
-            <router-link
-              :to="{
-                name: 'account_settings',
-                params: { id: id },
-              }"
-            >
-              <v-list-item
-                prepend-icon="mdi-cog"
-                title="Account"
-                value="account"
-              />
-            </router-link>
           </div>
 
           <div class="py-2">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Beschrijving
Zoals besproken wouden we de accountknop weg, en simpelweg kunnen klikken op de naam van de gebruiker.
closes #396 

## Screenshots (indien van toepassing):
![image](https://github.com/SELab-2/Dr-Trottoir-1/assets/109791839/9b90086d-6df7-48fd-8fab-0cb4edb5d867)

## Aanpassingen

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
New feature (non-breaking wijziging met nieuwe functionaliteit)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] De code volgt de stijl en guidelines van dit project.