### PR TITLE
API: oplossing bug #400

### DIFF
--- a/api/__tests__/mock/file.ts
+++ b/api/__tests__/mock/file.ts
@@ -9,13 +9,13 @@ export const manual = {
     mime: "application/pdf",
     path: "manual.pdf",
     location: "FILE_SERVER",
-    createdAt: new Date("1970-01-01T00:00:00"),
-    updatedAt: new Date("1970-01-01T00:00:00"),
+    createdAt: new Date("1970-01-01T00:00:00Z"),
+    updatedAt: new Date("1970-01-01T00:00:00Z"),
 } satisfies File;
 
 export const image = {
     id: 10,
-    time: new Date("1970-01-01T00:00:00"),
+    time: new Date("1970-01-01T00:00:00Z"),
     location: "IMGPROXY",
     path: "image.jpg",
     user_id: 1,

--- a/api/__tests__/mock/file.ts
+++ b/api/__tests__/mock/file.ts
@@ -2,7 +2,7 @@ import { File, Image } from "@selab-2/groep-1-orm";
 import { prisma } from "./prisma";
 
 export const manual = {
-    id: 1,
+    id: 10,
     user_id: 1,
     original_name: "handleiding.pdf",
     size_in_bytes: 1024,
@@ -14,7 +14,7 @@ export const manual = {
 } satisfies File;
 
 export const image = {
-    id: 1,
+    id: 10,
     time: new Date("1970-01-01T00:00:00"),
     location: "IMGPROXY",
     path: "image.jpg",

--- a/api/__tests__/routes/progress.test.ts
+++ b/api/__tests__/routes/progress.test.ts
@@ -1,0 +1,168 @@
+import { describe } from "@jest/globals";
+import { AuthenticationLevel, Testrunner } from "../utilities/Testrunner";
+import request from "supertest";
+import app from "../../src/main";
+import { resetDatabase } from "../mock/database";
+
+describe("Progress tests", () => {
+    let runner: Testrunner;
+    beforeAll(async () => {
+        const server = request(app);
+        runner = new Testrunner(server);
+
+        runner.authLevel(AuthenticationLevel.SUPER_STUDENT);
+
+        return resetDatabase();
+    });
+
+    describe("Bugs", () => {
+        test("Superstudent must not see deleted progress images", async () => {
+            runner.authLevel(AuthenticationLevel.SUPER_STUDENT);
+            await runner.delete({ url: "/progress/1/image/1" });
+
+            // verify that the progress image is soft deleted
+            // super-student should not see the deleted image
+            const expected = {
+                id: 1,
+                report: "Report 1",
+                arrival: "2023-05-04T12:00:00.000Z",
+                departure: "2023-05-04T12:00:00.000Z",
+                building_id: 1,
+                schedule_id: 1,
+                deleted: false,
+                building: {
+                    id: 1,
+                    name: "Building 1",
+                    ivago_id: "ivago-1",
+                    description: "Description of building 1",
+                    deleted: false,
+                    address: {
+                        id: 1,
+                        street: "Wallaby Way",
+                        number: 42,
+                        city: "Sydney",
+                        zip_code: 2000,
+                        latitude: -33.865143,
+                        longitude: 151.2099,
+                    },
+                },
+                schedule: {
+                    id: 1,
+                    day: "2023-05-04T12:00:00.000Z",
+                    start: "2023-05-04T12:10:00.000Z",
+                    end: "2023-05-04T12:20:00.000Z",
+                    user_id: 1,
+                    round_id: 1,
+                    deleted: false,
+                    round: {
+                        id: 1,
+                        name: "Round 1",
+                        description: "Description of round 1",
+                    },
+                    user: {
+                        id: 1,
+                        email: "student@trottoir.be",
+                        first_name: "Dirk",
+                        last_name: "De Student",
+                        last_login: "2023-05-04T12:00:00.000Z",
+                        date_added: "2023-05-04T12:00:00.000Z",
+                        phone: "0123456789",
+                        address_id: 1,
+                        student: true,
+                        super_student: false,
+                        admin: false,
+                        deleted: false,
+                    },
+                },
+                images: [],
+            };
+
+            await runner.get({
+                url: "/progress/1",
+                expectedData: [expected],
+            });
+
+            // Administrator should see the deleted image
+            const adminExpected = {
+                id: 1,
+                report: "Report 1",
+                arrival: "2023-05-04T12:00:00.000Z",
+                departure: "2023-05-04T12:00:00.000Z",
+                building_id: 1,
+                schedule_id: 1,
+                deleted: false,
+                building: {
+                    id: 1,
+                    name: "Building 1",
+                    ivago_id: "ivago-1",
+                    description: "Description of building 1",
+                    deleted: false,
+                    address: {
+                        id: 1,
+                        street: "Wallaby Way",
+                        number: 42,
+                        city: "Sydney",
+                        zip_code: 2000,
+                        latitude: -33.865143,
+                        longitude: 151.2099,
+                    },
+                },
+                schedule: {
+                    id: 1,
+                    day: "2023-05-04T12:00:00.000Z",
+                    start: "2023-05-04T12:10:00.000Z",
+                    end: "2023-05-04T12:20:00.000Z",
+                    user_id: 1,
+                    round_id: 1,
+                    deleted: false,
+                    round: {
+                        id: 1,
+                        name: "Round 1",
+                        description: "Description of round 1",
+                    },
+                    user: {
+                        id: 1,
+                        email: "student@trottoir.be",
+                        first_name: "Dirk",
+                        last_name: "De Student",
+                        last_login: "2023-05-04T12:00:00.000Z",
+                        date_added: "2023-05-04T12:00:00.000Z",
+                        phone: "0123456789",
+                        address_id: 1,
+                        student: true,
+                        super_student: false,
+                        admin: false,
+                        deleted: false,
+                    },
+                },
+                images: [
+                    {
+                        id: 1,
+                        type: "ARRIVAL",
+                        description: "Description of progress image 1",
+                        image_id: 10,
+                        progress_id: 1,
+                        deleted: true,
+                        image: {
+                            id: 10,
+                            time: "1969-12-31T23:00:00.000Z",
+                            location: "IMGPROXY",
+                            path: "image.jpg",
+                            user_id: 1,
+                        },
+                    },
+                ],
+            };
+
+            runner.authLevel(AuthenticationLevel.ADMINISTRATOR);
+            await runner.get({
+                url: "/progress/1",
+                expectedData: [adminExpected],
+            });
+        });
+    });
+
+    afterAll(() => {
+        app.close();
+    });
+});

--- a/api/__tests__/routes/progress.test.ts
+++ b/api/__tests__/routes/progress.test.ts
@@ -145,7 +145,7 @@ describe("Progress tests", () => {
                         deleted: true,
                         image: {
                             id: 10,
-                            time: "1969-12-31T23:00:00.000Z",
+                            time: "1970-01-01T00:00:00.000Z",
                             location: "IMGPROXY",
                             path: "image.jpg",
                             user_id: 1,

--- a/api/__tests__/utilities/Testrunner.ts
+++ b/api/__tests__/utilities/Testrunner.ts
@@ -113,7 +113,6 @@ export class Testrunner {
 
         const response = await this.server.get(url).set("Cookie", [cookie]);
         expect(response.statusCode).toEqual(statusCode);
-        console.log(util.inspect(response.body, { depth: null }));
         this.verifyBody(expectedData, response);
 
         return response;

--- a/api/__tests__/utilities/Testrunner.ts
+++ b/api/__tests__/utilities/Testrunner.ts
@@ -1,6 +1,7 @@
 import request from "supertest";
 import { expect } from "@jest/globals";
 import { constants } from "http2";
+import * as util from "util";
 
 /**
  * Describes different authentication levels.
@@ -112,6 +113,7 @@ export class Testrunner {
 
         const response = await this.server.get(url).set("Cookie", [cookie]);
         expect(response.statusCode).toEqual(statusCode);
+        console.log(util.inspect(response.body, { depth: null }));
         this.verifyBody(expectedData, response);
 
         return response;

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -58,6 +58,7 @@
       }
     },
     "../orm": {
+      "name": "@selab-2/groep-1-orm",
       "version": "1.0.18",
       "license": "ISC",
       "dependencies": {

--- a/api/src/validators/progress.validator.ts
+++ b/api/src/validators/progress.validator.ts
@@ -127,6 +127,7 @@ export class ProgressImageValidator extends Validator {
     deleteOneValidator() {
         return celebrate({
             params: Joi.object({
+                id: Joi.number().positive().required(),
                 image_id: Joi.number().positive().required(),
             }),
             body: Joi.object({


### PR DESCRIPTION
Closes #400.

<!--- Provide a general summary of your changes in the Title above -->

## Beschrijving

Lost de bug in issue #400 op door specifieke `.includes` te introduceren voor admin accounts. 

## Motivatie en context
Bij het schrijven van progress testen is er opgemerkt dat super studenten de soft verwijderede images kunnen zien.
Dit is niet de bedoeling, omdat enkel admin accounts de soft-verwijderde entities mogen zien.

## Testmethode
Er is een afzonderlijke test suite `Bugs` voorzien om deze (en toekomstige) bugs te testen en opsporen.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Aanpassingen
Aanpassingen aan de live code zijn dezelfde aanpassingen als de aanpassingen die geintroduceerd worden door #360.
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking wijziging die een probleem oplost)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] De code volgt de stijl en guidelines van dit project.
