### PR TITLE
Web: Carousel met afbeeldingen van gebouw

### DIFF
--- a/web/src/views/building/BuildingScreen.vue
+++ b/web/src/views/building/BuildingScreen.vue
@@ -1,11 +1,16 @@
 <template>
   <HFillWrapper v-if="building !== null">
     <v-card variant="text" class="space-y">
-      <img
-        alt="banner"
-        id="banner"
-        src="https://unsplash.com/photos/95YCW2X5jUc/download?force=true&w=1920"
-      />
+      <v-carousel hide-delimiters>
+        <v-carousel-item
+          v-for="entry in building.images"
+          :key="entry.id"
+          cover
+          :src="ImgProxy.env.url(entry.image)"
+        >
+        </v-carousel-item>
+      </v-carousel>
+
       <RemovedCard
         :show="useAuthStore().auth?.admin && building.deleted"
         title="Dit gebouw is verwijderd."
@@ -233,6 +238,7 @@ import SyndicusButtons from "@/components/building/SyndicusButtons.vue";
 import CardPopup from "@/components/popups/CardPopup.vue";
 import RemovedCard from "@/components/cards/RemovedCard.vue";
 import router from "@/router";
+import { ImgProxy } from "@/imgproxy";
 
 const showRemovePopup = ref(false);
 
@@ -394,7 +400,7 @@ async function restoreBuilding() {
 </script>
 
 <style lang="scss" scoped>
-#banner {
+.banner {
   width: 100%;
   max-height: 34vh;
   object-fit: cover;

--- a/web/src/views/building/BuildingScreen.vue
+++ b/web/src/views/building/BuildingScreen.vue
@@ -400,13 +400,6 @@ async function restoreBuilding() {
 </script>
 
 <style lang="scss" scoped>
-.banner {
-  width: 100%;
-  max-height: 34vh;
-  object-fit: cover;
-  border-radius: 5px;
-}
-
 .space-y {
   & > * {
     margin-bottom: 32px;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Beschrijving

De gebouwenpagina toont nu de verschillende afbeeldingen in carouselvorm.

## Motivatie en context

Deze feature was nog niet geimplementeerd. Omdat er meerdere afbeeldingen mogelijk zijn implementeren we deze als carousel (slide show).

De implementatie is eenvoudig met Vuetify:

```jsx
<v-carousel hide-delimiters>
  <v-carousel-item
    v-for="entry in building.images"
    :key="entry.id"
    cover
    :src="ImgProxy.env.url(entry.image)"
  >
  </v-carousel-item>
</v-carousel>
```

## Testmethode

Geen.

## Screenshots (indien van toepassing):

![image](https://github.com/SELab-2/Dr-Trottoir-1/assets/38297449/927fbe73-976a-4ed3-a5d0-29a04b71cc39)

## Aanpassingen

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking wijziging die een probleem oplost)
- [x] New feature (non-breaking wijziging met nieuwe functionaliteit)
- [ ] Breaking change (bestaande functionaliteit breekt door deze aanpassingen)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] De code volgt de stijl en guidelines van dit project.
- [ ] Vereist een aanpassing aan de documentatie. 
- [ ] De documentatie is gewijzigd.
