### PR TITLE
Frontend: Align icoontjes in niet-actieve tekstvelden.

### DIFF
--- a/web/src/components/forms/AddressForm.vue
+++ b/web/src/components/forms/AddressForm.vue
@@ -8,7 +8,6 @@
       >
         <!-- Text input field for the street name -->
         <v-text-field
-          prepend-inner-icon="mdi-road-variant"
           v-model="address.street"
           label="Straat"
           type="text"
@@ -17,7 +16,11 @@
           :readonly="readonly"
           :rules="streetRules"
           @update:model-value="$emit('onUpdate', address)"
-        ></v-text-field>
+        >
+          <template v-slot:prepend-inner>
+            <v-icon icon='mdi-road-variant' :class='readonly ? "mt-1" : ""'/>
+          </template>
+        </v-text-field>
       </v-col>
       <v-col
         v-show="!mobile"
@@ -48,7 +51,6 @@
       >
         <!-- Text input field for the city name -->
         <v-text-field
-          prepend-inner-icon="mdi-city-variant"
           v-model="address.city"
           label="Stad"
           type="text"
@@ -57,7 +59,11 @@
           :variant="readonly ? 'plain' : 'outlined'"
           :readonly="readonly"
           :rules="cityRules"
-        ></v-text-field>
+        >
+          <template v-slot:prepend-inner>
+            <v-icon icon='mdi-city-variant' :class='readonly ? "mt-1" : ""'/>
+          </template>
+        </v-text-field>
       </v-col>
       <v-col
         v-show="!mobile"

--- a/web/src/components/forms/AddressForm.vue
+++ b/web/src/components/forms/AddressForm.vue
@@ -18,7 +18,7 @@
           @update:model-value="$emit('onUpdate', address)"
         >
           <template v-slot:prepend-inner>
-            <v-icon icon='mdi-road-variant' :class='readonly ? "mt-1" : ""'/>
+            <v-icon icon="mdi-road-variant" :class="readonly ? 'mt-1' : ''" />
           </template>
         </v-text-field>
       </v-col>
@@ -61,7 +61,7 @@
           :rules="cityRules"
         >
           <template v-slot:prepend-inner>
-            <v-icon icon='mdi-city-variant' :class='readonly ? "mt-1" : ""'/>
+            <v-icon icon="mdi-city-variant" :class="readonly ? 'mt-1' : ''" />
           </template>
         </v-text-field>
       </v-col>

--- a/web/src/components/forms/ContactForm.vue
+++ b/web/src/components/forms/ContactForm.vue
@@ -12,7 +12,7 @@
       @update:model-value="$emit('onUpdate', contact)"
     >
       <template v-slot:prepend-inner>
-        <v-icon icon='mdi-phone' :class='readonly ? "mt-1" : ""'/>
+        <v-icon icon="mdi-phone" :class="readonly ? 'mt-1' : ''" />
       </template>
     </v-text-field>
     <v-text-field
@@ -26,7 +26,7 @@
       @update:model-value="$emit('onUpdate', contact)"
     >
       <template v-slot:prepend-inner>
-        <v-icon icon='mdi-email' :class='readonly ? "mt-1" : ""'/>
+        <v-icon icon="mdi-email" :class="readonly ? 'mt-1' : ''" />
       </template>
     </v-text-field>
   </v-list>

--- a/web/src/components/forms/ContactForm.vue
+++ b/web/src/components/forms/ContactForm.vue
@@ -2,7 +2,6 @@
   <v-list class="ma-0 pa-0">
     <v-text-field
       class="mt-2"
-      prepend-inner-icon="mdi-phone"
       label="Telefoonnummer"
       v-model="contact.phone"
       :variant="readonly ? 'plain' : 'outlined'"
@@ -11,10 +10,13 @@
       :counter="9"
       placeholder="0412345678"
       @update:model-value="$emit('onUpdate', contact)"
-    ></v-text-field>
+    >
+      <template v-slot:prepend-inner>
+        <v-icon icon='mdi-phone' :class='readonly ? "mt-1" : ""'/>
+      </template>
+    </v-text-field>
     <v-text-field
       class="mt-2 mb-1"
-      prepend-inner-icon="mdi-email"
       label="e-mail"
       v-model="contact.email"
       :variant="readonly ? 'plain' : 'outlined'"
@@ -22,7 +24,11 @@
       :rules="emailRules"
       placeholder="voorbeeld@voorbeeld.com"
       @update:model-value="$emit('onUpdate', contact)"
-    ></v-text-field>
+    >
+      <template v-slot:prepend-inner>
+        <v-icon icon='mdi-email' :class='readonly ? "mt-1" : ""'/>
+      </template>
+    </v-text-field>
   </v-list>
 </template>
 <script lang="ts" setup>


### PR DESCRIPTION
Sluit #476 .

## Beschrijving

Standaard aligneert vuetify de mdi-icons niet correct bij niet actieve tekstvelden. Aangezien het bij interactieve tekstvelden wel correct werkt hoeven we alleen een pixel marge toe te voegen bij inactieve tekstvelden.

## Screenshots (indien van toepassing):
![image](https://github.com/SELab-2/Dr-Trottoir-1/assets/91731084/bdbe1889-c8a4-4c34-b408-31c9efeacfe6)

## Aanpassingen

- [x] Bug fix (non-breaking wijziging die een probleem oplost)

## Checklist
- [x] De code volgt de stijl en guidelines van dit project.