### PR TITLE
web: datepickers niet geheel zichtbaar

### DIFF
--- a/web/src/views/building/GarbageMaker.vue
+++ b/web/src/views/building/GarbageMaker.vue
@@ -81,7 +81,6 @@
             >
               <v-text-field
                 v-model="startDate"
-                prepend-inner-icon="mdi-calendar"
                 variant="outlined"
                 type="date"
                 label="Startdatum"
@@ -89,7 +88,6 @@
 
               <v-text-field
                 v-model="endDate"
-                prepend-inner-icon="mdi-calendar"
                 variant="outlined"
                 type="date"
                 label="Einddatum"
@@ -97,7 +95,6 @@
               ></v-text-field>
 
               <v-text-field
-                prepend-inner-icon="mdi-clock-time-two-outline"
                 label="Starttijd"
                 variant="outlined"
                 type="time"

--- a/web/src/views/round/RoundPlanner.vue
+++ b/web/src/views/round/RoundPlanner.vue
@@ -90,7 +90,6 @@
 
               <v-text-field
                 v-model="startDate"
-                prepend-inner-icon="mdi-calendar"
                 variant="outlined"
                 type="date"
                 label="Startdatum"
@@ -98,7 +97,6 @@
 
               <v-text-field
                 v-model="endDate"
-                prepend-inner-icon="mdi-calendar"
                 variant="outlined"
                 type="date"
                 label="Einddatum"
@@ -106,7 +104,6 @@
               ></v-text-field>
 
               <v-text-field
-                prepend-inner-icon="mdi-clock-time-two-outline"
                 label="Starttijd"
                 variant="outlined"
                 type="time"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Beschrijving
Datum was niet altijd volledig zichtbaar door de icoontjes. Deze icoontjes zijn nu verwijderd.
Dit sluit #485 .
<!--- Describe your changes in detail -->

## Screenshots (indien van toepassing):
![image](https://github.com/SELab-2/Dr-Trottoir-1/assets/43027876/f589e184-3b53-4e7e-bee9-744b0a0d7279)

## Aanpassingen

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking wijziging die een probleem oplost)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] De code volgt de stijl en guidelines van dit project.
