### PR TITLE
Server: redirect alle URLs naar Vue

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -23,3 +23,5 @@
 !web/tsconfig.node.json
 !web/vite.config.ts
 !web/.browserslistrc
+
+!server/nginx.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -87,4 +87,7 @@ RUN rm -rf ./*
 # Copy artifacts
 COPY --from=web_build /build/web/dist ./
 
+# Copy configuration file
+COPY server/nginx.conf /etc/nginx/nginx.conf
+
 ENTRYPOINT ["nginx", "-g", "daemon off;"]

--- a/server/nginx.conf
+++ b/server/nginx.conf
@@ -1,0 +1,16 @@
+events {
+    worker_connections 4096;
+}
+
+http {
+    server {
+      listen 80;
+      server_name _ default_server;
+
+      root /usr/share/nginx/html;
+
+      location / {
+        try_files $uri $uri/ /index.html;
+      }
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Beschrijving

Een nieuwe nginx configuratie zorgt ervoor dat alles naar Vue gerouted wordt, en niet alleen de root pagina.

## Motivatie en context

Omdat Vue een Single Page Application is, bestaan de verschillende routes zoals `/account/` niet "echt". Daarom moeten we nginx manueel configuren om iedere request met `/index.html` te beantwoorden.

## Testmethode

Manueel.

## Screenshots (indien van toepassing):

## Aanpassingen

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking wijziging die een probleem oplost)
- [x] New feature (non-breaking wijziging met nieuwe functionaliteit)
- [ ] Breaking change (bestaande functionaliteit breekt door deze aanpassingen)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] De code volgt de stijl en guidelines van dit project.
- [ ] Vereist een aanpassing aan de documentatie. 
- [ ] De documentatie is gewijzigd.

Closes #494