### PR TITLE
Web: redesign van rondemaker

### DIFF
--- a/web/src/components/maps/MapComponent.vue
+++ b/web/src/components/maps/MapComponent.vue
@@ -42,7 +42,7 @@ const props = defineProps<{
 }>();
 
 function loc(building: Result<BuildingQuery>): [number, number] {
-  if (!building) return [0, 0];
+  if (!building) return [51.0229823, 3.7103475];
   return [building.address.latitude, building.address.longitude];
 }
 

--- a/web/src/views/round/RoundMaker.vue
+++ b/web/src/views/round/RoundMaker.vue
@@ -2,35 +2,30 @@
   <div class="grid">
     <MapComponent :buildings="newRoundBuildings" id="map" />
     <div>
-      <border-card
-        class="pa-2"
-        title="Ronde"
-        subtitle="De ronde zal in de volgorde van onderstaande lijst opgeslaan worden"
-      >
+      <border-card class="pa-5 mb-5">
+        <h2>Ronde</h2>
+        <p>De ronde wordt opgeslagen in onderstaande volgorde.</p>
         <v-text-field
-          class="ml-3 mr-5"
+          class="mt-3"
           label="Naam ronde"
           v-model="newRoundName"
           variant="outlined"
         />
         <v-textarea
-          class="ml-3 mr-5"
           label="Beschrijving"
           v-model="description"
           variant="outlined"
         />
-        <v-card-actions class="d-flex align-center"
-          ><v-spacer></v-spacer
-          ><v-btn
-            :disabled="
-              newRoundName === '' ||
-              description === '' ||
-              newRoundBuildings.length === 0
-            "
-            prepend-icon="mdi-check"
-            @click="makeRound()"
-            >Ronde aanmaken</v-btn
-          ></v-card-actions
+        <v-btn
+          :disabled="
+            newRoundName === '' ||
+            description === '' ||
+            newRoundBuildings.length === 0
+          "
+          style="width: 100%"
+          prepend-icon="mdi-check"
+          @click="makeRound()"
+          >Ronde aanmaken</v-btn
         >
       </border-card>
 
@@ -211,13 +206,11 @@ function moveBuildingDown(index: number) {
   display: grid;
   gap: 24px;
   padding: 0 24px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
 
-  @media (min-width: 501px) {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
-  @media (max-width: 500px) {
-    grid-template-columns: repeat(1, minmax(0, 1fr));
+  @media (max-width: 700px) {
+    display: flex;
+    flex-direction: column;
   }
 }
 

--- a/web/src/views/round/RoundMaker.vue
+++ b/web/src/views/round/RoundMaker.vue
@@ -1,25 +1,19 @@
 <template>
-  <div class="py-0 my-2 mx-5">
-    <MapComponent :buildings="newRoundBuildings" />
-  </div>
-  <v-row class="py-0 my-2 mx-2">
-    <v-col
-      cols="1"
-      style="min-width: 100px; max-width: 100%"
-      class="flex-grow-1 flex-shrink-0 py-0 my-0"
-      ><border-card
-        class="mb-4"
-        title="Ronde aanmaken"
+  <div class="grid">
+    <MapComponent :buildings="newRoundBuildings" id="map" />
+    <div>
+      <border-card
+        class="pa-2"
+        title="Ronde"
         subtitle="De ronde zal in de volgorde van onderstaande lijst opgeslaan worden"
       >
-        <template v-slot:append></template>
         <v-text-field
           class="ml-3 mr-5"
           label="Naam ronde"
           v-model="newRoundName"
           variant="outlined"
         />
-        <v-text-field
+        <v-textarea
           class="ml-3 mr-5"
           label="Beschrijving"
           v-model="description"
@@ -27,11 +21,19 @@
         />
         <v-card-actions class="d-flex align-center"
           ><v-spacer></v-spacer
-          ><v-btn class="ml-3" prepend-icon="mdi-check" @click="makeRound()"
+          ><v-btn
+            :disabled="
+              newRoundName === '' ||
+              description === '' ||
+              newRoundBuildings.length === 0
+            "
+            prepend-icon="mdi-check"
+            @click="makeRound()"
             >Ronde aanmaken</v-btn
           ></v-card-actions
         >
       </border-card>
+
       <building-select-card
         v-for="(building, i) in newRoundBuildings"
         :key="i"
@@ -43,22 +45,16 @@
         :address="getFullAddress(building)"
         :garbageinfo="garbageinfo"
       ></building-select-card>
-    </v-col>
-    <v-col
-      cols="2"
-      style="min-width: 100px; max-width: 100%"
-      class="flex-grow-1 flex-shrink-0 py-0 ml-5"
-      ><border-card
-        title="Zoeken in gebouwen"
-        subtitle="Klik op een gebouw om deze toe te voegen aan de lijst"
-        class="mb-4 pt-3"
-        ><v-text-field
-          class="ml-3 mr-5 mt-3"
-          label="Naam van gebouw"
-          v-model="searchquery"
-          variant="outlined"
-        />
-      </border-card>
+    </div>
+
+    <div>
+      <v-text-field
+        label="Naam van gebouw"
+        bg-color="white"
+        prepend-inner-icon="mdi-map-search"
+        v-model="searchquery"
+        variant="outlined"
+      />
 
       <building-info-card
         v-for="entry in filterlist()"
@@ -66,10 +62,9 @@
         :name="entry.building.name"
         :address="getFullAddress(entry.building)"
         @clicked="deleteBuildingFromAvailable(entry.listID, entry.building)"
-      >
-      </building-info-card>
-    </v-col>
-  </v-row>
+      />
+    </div>
+  </div>
 </template>
 
 <script lang="ts" setup>
@@ -210,3 +205,23 @@ function moveBuildingDown(index: number) {
   }
 }
 </script>
+
+<style lang="scss">
+.grid {
+  display: grid;
+  gap: 24px;
+  padding: 0 24px;
+
+  @media (min-width: 501px) {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  @media (max-width: 500px) {
+    grid-template-columns: repeat(1, minmax(0, 1fr));
+  }
+}
+
+#map {
+  grid-column: span 2 / span 2;
+}
+</style>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Beschrijving

Deze PR voegt consistentie en afwerking toe aan de rondemaker, alsook wat extra responsieve design. We maken gebruik van een CSS grid en een extra media query om deze op smalle devices om te zetten naar een flex box (column).

## Screenshots (indien van toepassing):

### Nieuw

![image](https://github.com/SELab-2/Dr-Trottoir-1/assets/38297449/4155e7c5-561a-4300-b339-213bc24bdfc0)

### Oud

![image](https://github.com/SELab-2/Dr-Trottoir-1/assets/38297449/53f0639b-d1c1-4854-b413-1eab0d97b966)


## Aanpassingen

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking wijziging die een probleem oplost)
- [ ] New feature (non-breaking wijziging met nieuwe functionaliteit)
- [ ] Breaking change (bestaande functionaliteit breekt door deze aanpassingen)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] De code volgt de stijl en guidelines van dit project.
- [ ] Vereist een aanpassing aan de documentatie. 
- [ ] De documentatie is gewijzigd.

Closes #518.